### PR TITLE
MMA-8336 se-dns Remove solarwind references

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ Execute the script
 ```python your_script.py example.com```
 
 ## Testing a branch ticket on this repository
-You can find an example [here](https://jira.solarwinds.com/browse/MMA-869?focusedCommentId=1717412&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1717412)
+You can find an example [here](https://n-able.atlassian.net/browse/MMA-869)


### PR DESCRIPTION
Why we need this
Review SWI & Solarwinds in code, documentation, file path, etc for backend repos.

Tickets/Links
[MMA-8336](https://n-able.atlassian.net/browse/MMA-8336)

How we fix it
Remove references.

[MMA-8336]: https://n-able.atlassian.net/browse/MMA-8336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ